### PR TITLE
Add the ability for middleware to receive options arguments

### DIFF
--- a/src/d2lfetch.js
+++ b/src/d2lfetch.js
@@ -18,16 +18,16 @@ export class D2LFetch {
 	}
 
 	use(middleware) {
-		const {name, fn} = this._verifyMiddleware(middleware);
-		this._installedMiddlewares.push({ name, fn: this._wrapMiddleware(fn) });
+		const {name, fn, options} = this._verifyMiddleware(middleware);
+		this._installedMiddlewares.push({ name, fn: this._wrapMiddleware(fn, options) });
 	}
 
 	addTemp(middleware) {
-		const {name, fn} = this._verifyMiddleware(middleware);
+		const {name, fn, options} = this._verifyMiddleware(middleware);
 		const self = new D2LFetch();
 
 		self._installedMiddlewares = this._installedMiddlewares.slice();
-		self._installedMiddlewares.push({ name, fn: self._wrapMiddleware(fn) });
+		self._installedMiddlewares.push({ name, fn: self._wrapMiddleware(fn, options) });
 
 		return self;
 	}
@@ -41,13 +41,13 @@ export class D2LFetch {
 		return self;
 	}
 
-	_wrapMiddleware(fn) {
+	_wrapMiddleware(fn, options) {
 		return (chain, request) => {
 			let next;
 			if (chain && chain.length !== 0) {
 				next = chain.shift().fn.bind(this, chain);
 			}
-			return fn(request, next);
+			return fn(request, next, options);
 		};
 	}
 

--- a/test/d2l-fetch/d2l-fetch.js
+++ b/test/d2l-fetch/d2l-fetch.js
@@ -80,6 +80,13 @@ describe('d2l-fetch', function() {
 			expect(window.d2lfetch._wrapMiddleware).to.be.calledWith(passthroughMiddleware);
 		});
 
+		it('should pass optional use options in to the wrap function', function() {
+			const useOptions = { found: true };
+			sandbox.spy(window.d2lfetch, '_wrapMiddleware');
+			window.d2lfetch.use({ name: 'passthroughMiddleware', fn: passthroughMiddleware, options: useOptions });
+			expect(window.d2lfetch._wrapMiddleware).to.be.calledWith(passthroughMiddleware, useOptions);
+		});
+
 		it('should add the wrapped function to the _installedMiddlewares array', function() {
 			expect(window.d2lfetch._installedMiddlewares.length).to.equal(0);
 			window.d2lfetch.use({ name: 'passthroughMiddleware', fn: passthroughMiddleware });
@@ -170,6 +177,13 @@ describe('d2l-fetch', function() {
 				var response = window.d2lfetch.fetch(getRequest());
 				expect(response).to.equal(windowFetchResponse);
 			});
+
+			it('should pass provided options to the middleware function when calling it', function() {
+				const useOptions = { found: true };
+				window.d2lfetch.use({ name: 'passthroughSpy', fn: passthroughSpy, options: useOptions });
+				window.d2lfetch.fetch(getRequest());
+				expect(passthroughSpy.getCall(0).args[2]).to.equal(useOptions);
+			});
 		});
 
 		describe('when multiple middlewares are use\'d', function() {
@@ -208,6 +222,18 @@ describe('d2l-fetch', function() {
 				expect(passthroughSpy).to.be.calledBefore(anotherSpy);
 				expect(anotherSpy).to.be.calledBefore(window.fetch);
 				expect(window.fetch).to.be.called;
+			});
+
+			it('should pass the appropriate use options to each middleware function when called', function() {
+				const passthroughSpyOptions = { found: true };
+				const earlyExitSpyOptions = { found: false };
+				window.d2lfetch.use({ name: 'passthroughSpy', fn: passthroughSpy, options: passthroughSpyOptions });
+				window.d2lfetch.use({ name: 'anotherSpy', fn: anotherSpy });
+				window.d2lfetch.use({ name: 'earlyExitSpy', fn: earlyExitSpy, options: earlyExitSpyOptions });
+				window.d2lfetch.fetch(getRequest());
+				expect(passthroughSpy.getCall(0).args[2]).to.equal(passthroughSpyOptions);
+				expect(anotherSpy.getCall(0).args[2]).to.be.undefined;
+				expect(earlyExitSpy.getCall(0).args[2]).to.equal(earlyExitSpyOptions);
 			});
 		});
 	});


### PR DESCRIPTION
Currently a middleware function can only receive the fetch `Request` object and a reference to the next middleware in the chain. This change allows for an `options` parameter to be configured at `.use` time and then passed to the function during execution. This can allow for configuration of the middleware.