### PR TITLE
Disable frau-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
 - npm run test:lint
 - wct --skip-plugin local
 - ./update.sh
-- 'if [ "$TRAVIS_BRANCH" == "master" ]; then frauci-update-version && export TRAVIS_TAG=$(frauci-get-version) && npm run build && npm run publish-release; fi'
+# - 'if [ "$TRAVIS_BRANCH" == "master" ]; then frauci-update-version && export TRAVIS_TAG=$(frauci-get-version) && npm run build && npm run publish-release; fi'
 env:
   global:
   - REPO_NAME=d2l-fetch


### PR DESCRIPTION
Looks like frau-ci doesn't pull before trying to push the version update commit, which means it won't work here, since the working tree is one commit behind (i.e. the Travis-autogenerating-d2l-fetch.html commit is missing). Disabling it for now (fallback to manual releases) until this can be rectified within frau-ci.