### PR TITLE
Use deumdify browserify plugin

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ var browserify = require('browserify');
 var babelify = require('babelify');
 var uglify = require('gulp-uglify');
 var change = require('gulp-change');
+var deumdify = require('deumdify');
 
 // make the global variable assignment conditional on if it has already been assigned
 function windowify(content) {
@@ -15,6 +16,7 @@ function windowify(content) {
 
 gulp.task('scripts', function() {
 	var bundler = browserify('./src/index.js', { standalone: 'd2lfetch' })
+		.plugin(deumdify)
 		.transform(babelify, { presets: [ 'env' ] });
 
 	return bundler.bundle()

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bower": "^1.8.0",
     "browserify": "^14.4.0",
     "cross-env": "^5.0.0",
+    "deumdify": "^1.2.4",
     "eslint": "^3.19.0",
     "eslint-config-brightspace": "^0.2.4",
     "eslint-plugin-html": "^2.0.1",


### PR DESCRIPTION
We were seeing an issue where requirejs being on the same page was causing problems, specifically http://requirejs.org/docs/errors.html#mismatch. This was only happening on UMD FRA pages in the LMS. We're not using the UMD-ness of d2l-fetch, so might as well remove it to stop causing problems.

Note that this will be a major version bump since this is technically a breaking change (albeit breaking in a way we don't use, but better safe than sorry).

Tried this out in BSI locally and it does indeed solve the problem we were seeing in FF/IE11 (and doesn't have any negative effect on My Courses or the course banner, both of which are using d2lfetch).

Inspired by https://github.com/Brightspace/node-siren-parser/pull/11