### PR TITLE
Reset version numbers that aren't being bumped

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -24,10 +24,16 @@ majorRegex='\[increment major\]'
 patchRegex='\[increment patch\]'
 if [[ $lastLogMessage =~ $majorRegex ]]; then
 	majorVersion=$((majorVersion + 1))
+	minorVersion=0
+	patchVersion=0
 elif [[ $lastLogMessage =~ $patchRegex ]]; then
+	majorVersion=0
+	minorVersion=0
 	patchVersion=$((patchVersion + 1))
 else
+	majorVersion=0
 	minorVersion=$((minorVersion + 1))
+	patchVersion=0
 fi
 
 newVersion="${majorVersion}.${minorVersion}.${patchVersion}"


### PR DESCRIPTION
Otherwise we go 1.5.1 -> 2.5.1, as just happened.