### PR TITLE
Change windowify to fix bug introduced with deumdify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ var deumdify = require('deumdify');
 
 // make the global variable assignment conditional on if it has already been assigned
 function windowify(content) {
-	return content.replace('g.d2lfetch = f()', 'g.d2lfetch = g.d2lfetch || f()');
+	return content.replace('g\.d2lfetch\s*=\s*f\(\)', 'g.d2lfetch = g.d2lfetch || f()');
 }
 
 gulp.task('scripts', function() {


### PR DESCRIPTION
Adding the deumdify plugin to browserify was just changing a bit of whitespace, which caused d2lfetch to always replacing the existing d2lfetch. Now uses a regex to match instead.