### PR TITLE
dry-run = false

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,4 +23,3 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
           NPM: false
-          DRY_RUN: true


### PR DESCRIPTION
> [2:25:20 PM] [semantic-release] › ℹ  There are no relevant changes, so no new version is released.
https://github.com/Brightspace/d2l-fetch/runs/1742388527?check_suite_focus=true

Should be safe to turn it on now