### PR TITLE
add prepend option to addTemp

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ window.d2lfetch
 	});
 ```
 
-If you want to have the temporary middleware added to the beginning of the middle chain, you can pass `prepend: true` into the options object.
+If you want to have the temporary middleware added to the beginning of the middleware chain, you can pass `prepend: true` into the options object.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ window.d2lfetch
 	});
 ```
 
+If you want to have the temporary middleware added to the beginning of the middle chain, you can pass `prepend: true` into the options object.
+
+Example:
+
+```js
+window.d2lfetch.use({name: 'myMiddlewareName', fn: myMiddlewareFunc});
+
+window.d2lfetch
+	.addTemp(
+		{ name: 'addedMiddlewareName', fn: function() { /* added middleware functionality */ } },
+		{ prepend: true }
+	)
+```
+
 ### RemoveTemp
 
 Use the `removeTemp` function to temporarily remove a specified middleware from the middleware chain. Returns a new `D2LFetch` object with the updated middleware chain.

--- a/src/d2lfetch.js
+++ b/src/d2lfetch.js
@@ -22,12 +22,17 @@ export class D2LFetch {
 		this._installedMiddlewares.push({ name, fn: this._wrapMiddleware(fn, options) });
 	}
 
-	addTemp(middleware) {
+	addTemp(middleware, { prepend = false } = { prepend: false } ) {
 		const {name, fn, options} = this._verifyMiddleware(middleware);
 		const self = new D2LFetch();
 
 		self._installedMiddlewares = this._installedMiddlewares.slice();
-		self._installedMiddlewares.push({ name, fn: self._wrapMiddleware(fn, options) });
+		const toAdd = { name, fn: self._wrapMiddleware(fn, options) };
+		if (prepend) {
+			self._installedMiddlewares.unshift(toAdd);
+		} else {
+			self._installedMiddlewares.push(toAdd);
+		}
 
 		return self;
 	}


### PR DESCRIPTION
This is meant to address an issue I'm seeing in activity feed in BFP.

The top level d2l-fetch has auth, dedupe, and cache enabled. Activity feed adds a new auth value at the end of the chain with a custom temp middleware, but since this is at the end of the chain, the provided token isn't taken into account when resolving the cache key, causing calls with different tokens to cache as if they all had the same token.

Being able to prepend the temp middleware to the start of the chain will allow it to resolve before any cache or dedupe logic runs