### PR TITLE
Add missing `.js` extension to import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-import { D2LFetch } from './d2lfetch';
+import { D2LFetch } from './d2lfetch.js';
 export const d2lfetch = new D2LFetch();


### PR DESCRIPTION
## Description

Was trying to install this dependency and was met with the following error:

```Module not found: Error: Can't resolve './d2lfetch' in '/home/runner/work/folio-app/folio-app/node_modules/d2l-fetch/src'
Did you mean 'd2lfetch.js'?
BREAKING CHANGE: The request './d2lfetch' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

I think this is the required solution here.