### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "/src",
     "d2l-fetch.js"
   ],
-  "version": "2.7.2"
+  "version": "2.7.2",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  }
 }


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564